### PR TITLE
Fixed issue with local time conversion

### DIFF
--- a/SitecoreShipFunctions.psm1
+++ b/SitecoreShipFunctions.psm1
@@ -658,7 +658,7 @@ function Get-SitecoreShipLastCompletedPublish
         $time = Invoke-RestMethod $serviceUrl -Method GET -TimeoutSec $Timeout
         if (!$ResultAsUniversalTime)
         {
-            $time = $time.ToLocalTime()
+            $time = $time.date.ToLocalTime()
         }
         return $time
     }

--- a/SitecoreShipFunctions.psm1
+++ b/SitecoreShipFunctions.psm1
@@ -53,6 +53,16 @@ function Get-FormData([string[]]$dataArray, [string]$boundaryId)
     return $contents.ToString()
 }
 
+function Get-LocalTime([object]$time)
+{
+    if ($time -is [PSObject] -and ($time.psobject.Properties | where { $_.Name -eq "date"}))
+    {
+        return $time.date.ToLocalTime()
+    }
+
+    return $time.ToLocalTime()
+}
+
 #endregion
 
 #region Public Functions
@@ -546,7 +556,7 @@ function Invoke-SitecoreShipPublishRequest
         $time = $data | ConvertFrom-Json
         if (!$ResultAsUniversalTime)
         {
-            $time = $time.ToLocalTime()
+            $time = Get-LocalTime($time)
         }
 
         return $time
@@ -658,7 +668,7 @@ function Get-SitecoreShipLastCompletedPublish
         $time = Invoke-RestMethod $serviceUrl -Method GET -TimeoutSec $Timeout
         if (!$ResultAsUniversalTime)
         {
-            $time = $time.date.ToLocalTime()
+            $time = Get-LocalTime($time)
         }
         return $time
     }


### PR DESCRIPTION
As discussed [on twitter](https://twitter.com/Patrick_Perrone/status/708298569678241792). The $time object on my machine and on our server is of type [psobject] and has a 'date' property of type [System.DateTime].

Powershell version:

| Name | Value |
| --- | --- |
| PSVersion | 4.0 |
| WSManStackVersion | 3.0 |
| SerializationVersion | 1.1.0.1 |
| CLRVersion | 4.0.30319.42000 |
| BuildVersion | 6.3.9600.16406 |
| PSCompatibleVersions | {1.0, 2.0, 3.0, 4.0} |
| PSRemotingProtocolVersion | 2.2 |
